### PR TITLE
Fixes for 'concurrency' issues in JobQueue and JobManager

### DIFF
--- a/jobManager.py
+++ b/jobManager.py
@@ -67,7 +67,7 @@ class JobManager(object):
         while True:
             # Gets the next pending job/ id
             # Blocks until we get a next job
-            job, _ = self.jobQueue.getNextPendingJobFromQueue()
+            job = self.jobQueue.getNextPendingJobFromQueue()
 
             if not job.accessKey and Config.REUSE_VMS:
                 vm = self.jobQueue.reuseVM(job)

--- a/jobManager.py
+++ b/jobManager.py
@@ -69,6 +69,8 @@ class JobManager(object):
             # NOTE: This grabs and acquires the lock on the queue
             # If there is no pending job, job and id is None
             job, _ = self.jobQueue.getNextPendingJobFromQueue()
+            # If there is no pending job, then we continue with 
+            # the loop
             if job is None:
                 continue
 

--- a/jobManager.py
+++ b/jobManager.py
@@ -67,7 +67,7 @@ class JobManager(object):
         while True:
             # Gets the next pending job/ id
             # Blocks until we get a next job
-            job = self.jobQueue.getNextPendingJobFromQueue()
+            job = self.jobQueue.getNextPendingJob()
 
             if not job.accessKey and Config.REUSE_VMS:
                 vm = self.jobQueue.reuseVM(job)

--- a/jobManager.py
+++ b/jobManager.py
@@ -96,19 +96,17 @@ class JobManager(object):
                         preVM = self.preallocator.allocVM(job.vm.name)
                     vmms = self.vmms[job.vm.vmms]  # Create new vmms object
 
-                if job is None:
-                    raise Exception("here1")
- 
-                # Now dispatch the job to a worker 
-                self.log.info("Dispatched job %s:%d to %s [try %d]" %
+                if (preVM is not None):
+                    # Log the preallocated vm only in the case where a vm 
+                    # was allocated
+                    self.log.info("Dispatched job %s:%d to %s [try %d]" %
                               (job.name, job.id, preVM.name, job.retries))
-                if job is None:
-                    raise Exception("here")
  
-                # job.appendTrace(
-                #    "%s|Dispatched job %s:%d [try %d]" %
-                #    (datetime.utcnow().ctime(), job.name, job.id, job.retries))
+                job.appendTrace(
+                   "%s|Dispatched job %s:%d [try %d]" %
+                   (datetime.utcnow().ctime(), job.name, job.id, job.retries))
 
+                # Now dispatch the job to a worker 
                 Worker(
                     job,
                     vmms,

--- a/jobManager.py
+++ b/jobManager.py
@@ -69,14 +69,14 @@ class JobManager(object):
                 job = self.jobQueue.get(id)
 
                 # job could no longer exist if it was completed by someone else
-                if job == None:
-                    continue
+                # if job == None:
+                #     continue
 
                 if not job.accessKey and Config.REUSE_VMS:
                     id, vm = self.jobQueue.getNextPendingJobReuse(id)
                     job = self.jobQueue.get(id)
-                    if job == None:
-                        continue
+                    # if job == None:
+                    #     continue
 
                 try:
                     # Mark the job assigned

--- a/jobManager.py
+++ b/jobManager.py
@@ -1,4 +1,16 @@
 from __future__ import print_function
+import copy
+import time
+import logging
+import threading
+from config import Config
+from tangoObjects import TangoQueue
+from worker import Worker
+from preallocator import Preallocator
+from jobQueue import JobQueue
+from tango import *
+from datetime import datetime
+from builtins import str
 #
 # JobManager - Thread that assigns jobs to worker threads
 #
@@ -13,17 +25,7 @@ from __future__ import print_function
 from builtins import object
 from future import standard_library
 standard_library.install_aliases()
-from builtins import str
-import threading, logging, time, copy
 
-from datetime import datetime
-from tango import *
-from jobQueue import JobQueue
-from preallocator import Preallocator
-from worker import Worker
-
-from tangoObjects import TangoQueue
-from config import Config
 
 class JobManager(object):
 
@@ -63,59 +65,61 @@ class JobManager(object):
     def __manage(self):
         self.running = True
         while True:
-            id = self.jobQueue.getNextPendingJob()
+            # Gets the next pending job/ id
+            # NOTE: This grabs and acquires the lock on the queue
+            # If there is no pending job, job and id is None
+            job, _ = self.jobQueue.getNextPendingJobFromQueue()
+            if job is None:
+                continue
 
-            if id:
-                job = self.jobQueue.get(id)
+            if not job.accessKey and Config.REUSE_VMS:
+                vm = self.jobQueue.reuseVM(job)
 
-                # job could no longer exist if it was completed by someone else
-                # if job == None:
-                #     continue
+            try:
+                # Mark the job assigned
+                job.makeAssigned()
+                # if the job has specified an account
+                # create an VM on the account and run on that instance
+                if job.accessKeyId:
+                    from vmms.ec2SSH import Ec2SSH
+                    vmms = Ec2SSH(job.accessKeyId, job.accessKey)
+                    newVM = copy.deepcopy(job.vm)
+                    newVM.id = self._getNextID()
+                    preVM = vmms.initializeVM(newVM)
 
-                if not job.accessKey and Config.REUSE_VMS:
-                    id, vm = self.jobQueue.getNextPendingJobReuse(id)
-                    job = self.jobQueue.get(id)
-                    # if job == None:
-                    #     continue
-
-                try:
-                    # Mark the job assigned
-                    self.jobQueue.assignJob(job.id)
-                    # if the job has specified an account
-                    # create an VM on the account and run on that instance
-                    if job.accessKeyId:
-                        from vmms.ec2SSH import Ec2SSH
-                        vmms = Ec2SSH(job.accessKeyId, job.accessKey)
-                        newVM = copy.deepcopy(job.vm)
-                        newVM.id = self._getNextID()
-                        preVM = vmms.initializeVM(newVM)
+                else:
+                    # Try to find a vm on the free list and allocate it to
+                    # the worker if successful.
+                    if Config.REUSE_VMS:
+                        preVM = vm
                     else:
-                        # Try to find a vm on the free list and allocate it to
-                        # the worker if successful.
-                        if Config.REUSE_VMS:
-                            preVM = vm
-                        else:
-                            preVM = self.preallocator.allocVM(job.vm.name)
-                        vmms = self.vmms[job.vm.vmms]  # Create new vmms object
+                        preVM = self.preallocator.allocVM(job.vm.name)
+                    vmms = self.vmms[job.vm.vmms]  # Create new vmms object
 
-                    # Now dispatch the job to a worker
-                    self.log.info("Dispatched job %s:%d to %s [try %d]" %
-                                  (job.name, job.id, preVM.name, job.retries))
-                    job.appendTrace(
-                        "%s|Dispatched job %s:%d [try %d]" %
-                        (datetime.utcnow().ctime(), job.name, job.id, job.retries))
+                if job is None:
+                    raise Exception("here1")
+ 
+                # Now dispatch the job to a worker 
+                self.log.info("Dispatched job %s:%d to %s [try %d]" %
+                              (job.name, job.id, preVM.name, job.retries))
+                if job is None:
+                    raise Exception("here")
+ 
+                # job.appendTrace(
+                #    "%s|Dispatched job %s:%d [try %d]" %
+                #    (datetime.utcnow().ctime(), job.name, job.id, job.retries))
 
-                    Worker(
-                        job,
-                        vmms,
-                        self.jobQueue,
-                        self.preallocator,
-                        preVM
-                    ).start()
-
-                except Exception as err:
-                    self.jobQueue.makeDead(job.id, str(err))
-
+                Worker(
+                    job,
+                    vmms,
+                    self.jobQueue,
+                    self.preallocator,
+                    preVM
+                 ).start()
+            except Exception as err:
+                print("EXCEPTION")
+                print(str(err))
+                
             # Sleep for a bit and then check again
             time.sleep(Config.DISPATCH_PERIOD)
 

--- a/jobManager.py
+++ b/jobManager.py
@@ -66,13 +66,8 @@ class JobManager(object):
         self.running = True
         while True:
             # Gets the next pending job/ id
-            # NOTE: This grabs and acquires the lock on the queue
-            # If there is no pending job, job and id is None
+            # Blocks until we get a next job
             job, _ = self.jobQueue.getNextPendingJobFromQueue()
-            # If there is no pending job, then we continue with 
-            # the loop
-            if job is None:
-                continue
 
             if not job.accessKey and Config.REUSE_VMS:
                 vm = self.jobQueue.reuseVM(job)

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -37,9 +37,29 @@ from config import Config
 class JobQueue(object):
 
     def __init__(self, preallocator):
-        self.liveJobs = TangoDictionary("liveJobs2")
-        self.deadJobs = TangoDictionary("deadJobs2")
-        self.unassignedJobs = TangoQueue("unassigneds2")
+        """
+        Here we maintain several data structures used to keep track of the 
+        jobs present for the autograder. 
+
+        Live jobs contains:
+        - jobs that are yet to be assigned and run
+        - jobs that are currently running
+
+        Dead jobs contains: 
+        - jobs that have been completed, or have been 'deleted' when in
+          the live jobs queue
+
+        This is a FIFO queue of jobs that are pending assignment. 
+        - We enforce the invariant that all jobs in this queue must be 
+          present in live jobs
+
+        queueLock protects all the internal data structure of JobQueue. This 
+        is needed since there are multiple worker threads and they might be 
+        using the makeUnassigned api.
+        """
+        self.liveJobs = TangoDictionary("liveJobs")
+        self.deadJobs = TangoDictionary("deadJobs")
+        self.unassignedJobs = TangoQueue("unassignedLiveJobs")
         self.queueLock = threading.Lock()
         self.preallocator = preallocator
         self.log = logging.getLogger("JobQueue")
@@ -83,19 +103,29 @@ class JobQueue(object):
     def add(self, job):
         """add - add job to live queue
 
-        This function assigns an ID number to a job and then adds it
-        to the queue of live jobs.
+        This function assigns an ID number to a *new* job and then adds it
+        to the queue of live jobs. 
+
+        Returns the job id on success, -1 otherwise 
         """
         if (not isinstance(job, TangoJob)):
             return -1
+
+        # Get an id for the new job
         self.log.debug("add|Getting next ID")
-        job.setId(self._getNextID())
-        if (job.id == -1):
+        nextId = self._getNextID()
+        if (nextId.id == -1):
             self.log.info("add|JobQueue is full")
             return -1
+        job.setId(nextId)
         self.log.debug("add|Gotten next ID: " + str(job.id))
+
         self.log.info("add|Unassigning job ID: %d" % (job.id))
+        # Make the job unassigned
         job.makeUnassigned()
+
+        # Since we assume that the job is new, we set the number of retries 
+        # of this job to 0
         job.retries = 0
 
         # Add the job to the queue. Careful not to append the trace until we
@@ -104,9 +134,11 @@ class JobQueue(object):
         self.queueLock.acquire()
         self.log.debug("add| Acquired lock to job queue.")
 
+        # Adds the job to the live jobs dictionary
         self.liveJobs.set(job.id, job)
+
         # Add this to the unassigned job queue too 
-        self.unassignedJobs.put(job)
+        self.unassignedJobs.put(job.id)
 
         job.appendTrace("%s|Added job %s:%d to queue" %
                         (datetime.utcnow().ctime(), job.name, job.id))
@@ -126,15 +158,21 @@ class JobQueue(object):
     def addDead(self, job):
         """ addDead - add a job to the dead queue.
 
-        Called by validateJob when a job validation fails.
+        Called by validateJob when a job validation fails. 
+        Return -1 on failure and the job id on success
         """
         if (not isinstance(job, TangoJob)):
             return -1
 
-        job.setId(self._getNextID())
-        if (job.id == -1):
+        # Get an id for the new job
+        self.log.debug("add|Getting next ID")
+        nextId = self._getNextID()
+        if (nextId.id == -1):
             self.log.info("add|JobQueue is full")
             return -1
+        job.setId(nextId)
+        self.log.debug("add|Gotten next ID: " + str(job.id))
+
         self.log.info("addDead|Unassigning job %s" % str(job.id))
         job.makeUnassigned()
         job.retries = 0
@@ -143,6 +181,7 @@ class JobQueue(object):
         self.queueLock.acquire()
         self.log.debug("addDead|Acquired lock to job queue.")
 
+        # We add the job into the dead jobs dictionary
         self.deadJobs.set(job.id, job)
         self.queueLock.release()
         self.log.debug("addDead|Released lock to job queue.")
@@ -188,18 +227,6 @@ class JobQueue(object):
         self.log.debug("get| Released lock to job queue.")
         return job
 
-    def getNextPendingJob(self):
-        """getNextPendingJob - Returns ID of next pending job from queue.
-        Called by JobManager when Config.REUSE_VMS==False
-        """
-        self.queueLock.acquire()
-        for id, job in self.liveJobs.items():
-            if job.isNotAssigned():
-                self.queueLock.release()
-                return job, id
-        self.queueLock.release()
-        return None, None
-
     def getNextPendingJobReuse(self, target_id=None):
         """getNextPendingJobReuse - Returns ID of next pending job and its VM.
         Called by JobManager when Config.REUSE_VMS==True
@@ -220,20 +247,21 @@ class JobQueue(object):
                 if vm:
                     self.queueLock.release()
                     return (id, vm)
-
         self.queueLock.release()
         return (None, None)
 
-    # TODO Remove this interface 
     def assignJob(self, jobId):
         """ assignJob - marks a job to be assigned
+
+        Note: This is currently not used
         """
         self.queueLock.acquire()
         self.log.debug("assignJob| Acquired lock to job queue.")
 
         job = self.liveJobs.get(jobId)
-        # Remove from the unassigned jobs list
-        # self.unassignedJobs.popBack()
+
+        # Remove the current job from the queue
+        self.unassignedJobs.remove(jobId)
 
         self.log.debug("assignJob| Retrieved job.")
         self.log.info("assignJob|Assigning job ID: %s" % str(job.id))
@@ -243,23 +271,29 @@ class JobQueue(object):
         self.queueLock.release()
         self.log.debug("assignJob| Released lock to job queue.")
 
-    # Note: It seems here that you also assume that a job is being 
-    # retried when you unassign it
     def unassignJob(self, jobId):
         """ assignJob - marks a job to be unassigned
+            Note: We assume here that a job is to be rescheduled or 
+            'retried' when you unassign it. This retry is done by
+            the worker.
         """
         self.queueLock.acquire()
         self.log.debug("unassignJob| Acquired lock to job queue.")
+
+        # Get the current job
         job = self.liveJobs.get(jobId)
+
+        # Increment the number of retries
         if job.retries is None:
             job.retries = 0
         else:
             job.retries += 1
             Config.job_retries += 1
 
-        # Add to the unassigned jobs list if it is not already there
-        # if str(jobId) not in self.unassignedJobs.keys():
-        #    self.unassignedJobs.pushBack(jobId)
+        # Since the assumption is that the job is being retried, 
+        # we simply add the job to the unassigned jobs queue without 
+        # removing anything from it
+        self.unassignedJobs.put(jobId)
 
         self.log.info("unassignJob|Unassigning job %s" % str(job.id))
         job.makeUnassigned()
@@ -273,21 +307,28 @@ class JobQueue(object):
         self.queueLock.acquire()
         self.log.debug("makeDead| Acquired lock to job queue.")
         status = -1
+        
+        # Check to make sure that the job is in the live jobs queue
         if str(id) in self.liveJobs.keys():
             self.log.info(
                 "makeDead| Found job ID: %d in the live queue" % (id))
             status = 0
+            # Get the job from the dictionary
             job = self.liveJobs.get(id)
+
+            if job is None:
+                raise Exception("Cannot find unassigned job in live jobs")
+
             self.log.info("Terminated job %s:%d: %s" %
                           (job.name, job.id, reason))
+            # Add the job to the dead jobs dictionary
             self.deadJobs.set(id, job)
+            # Remove the job from the live jobs dictionary 
             self.liveJobs.delete(id)
-            job.appendTrace("%s|%s" % (datetime.utcnow().ctime(), reason))
+            # Remove the job from the unassigned queue too
+            self.unassignedJobs.remove(id)
 
-        # If this job is in unassigned jobs, remove it from the 
-        # unassigned jobs list too 
-        # if str(id) in self.unassignedJobs.keys():
-        #    self.unassignedJobs.delete(id)
+            job.appendTrace("%s|%s" % (datetime.utcnow().ctime(), reason))
 
         self.queueLock.release()
         self.log.debug("makeDead| Released lock to job queue.")
@@ -300,46 +341,54 @@ class JobQueue(object):
         return info
 
     def reset(self):
-        # TODO fix this
+        """ reset - resets and clears all the internal dictionaries 
+                    and queues
+        """
         self.liveJobs._clean()
+        self.unassignedJobs._clean()
         self.deadJobs._clean()
 
-    def _getPendingJobNoLock(self):
-        for id, job in self.liveJobs.items():
-            if job.isNotAssigned():
-                return job, id
-        return None, None
-
-       
-
     def getNextPendingJobFromQueue(self):
+        """Gets the next unassigned live job. Note that this is a 
+           blocking function and we will block till there is an available 
+           job.
+        """
         self.log.debug("_getNextPendingJob|Acquiring lock to job queue.")
         self.queueLock.acquire()
         self.log.debug("_getNextPendingJob|Acquired lock to job queue.")
+
         # Blocks till the next item is added 
-        job = self.unassignedJobs.get()
+        id = self.unassignedJobs.get()
+        # Get the corresponding job
+        job = self.liveJobs.get(id)
+        if job is None:
+            raise Exception("Cannot find unassigned job in live jobs")
+
         self.log.debug("getNextPendingJob| Releasing lock to job queue.")
         self.queueLock.release()
         self.log.debug("getNextPendingJob| Released lock to job queue.")
-        return job, id
+        return job
  
     def reuseVM(self, job):
+        """Helps a job reuse a vm. This is called if CONFIG.REUSE_VM is 
+           set to true.
+        """
+
         # Create a pool if necessary
+        # This is when there is no existing pool for the vm name required.
         if self.preallocator.poolSize(job.vm.name) == 0:
             self.preallocator.update(job.vm, Config.POOL_SIZE)
 
-        # If the job hasn't been assigned to a worker yet, see if there
-        # is a free VM
+        # If the job hasn't been assigned to a worker yet, we try to 
+        # allocate a new vm for this job
         if (job.isNotAssigned()):
-            vm = self.preallocator.allocVM(job.vm.name)
-            if vm:
-                return vm
-            else: 
-                # No Vms to assign
-                return None
+            # Note: This could return None, when all VMs are being used
+            return self.preallocator.allocVM(job.vm.name)
         else:
-            if vm:
-                return vm
+            # In the case where a job is already assigned, it should have 
+            # a vm, and we just return that vm here
+            if job.vm:
+                return job.vm
             else:
                 raise Exception("Job assigned without vm")
 

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -289,7 +289,7 @@ class JobQueue(object):
         # Check to make sure that the job is in the live jobs queue
         if str(id) in self.liveJobs.keys():
             self.log.info(
-                "makeDead| Found job ID: %d in the live queue" % (id))
+                "makeDead| Found job ID: %d in the live queue", (id))
             status = 0
             # Get the job from the dictionary
             job = self.liveJobs.get(id)
@@ -326,7 +326,7 @@ class JobQueue(object):
         self.unassignedJobs._clean()
         self.deadJobs._clean()
 
-    def getNextPendingJobFromQueue(self):
+    def getNextPendingJob(self):
         """Gets the next unassigned live job. Note that this is a 
            blocking function and we will block till there is an available 
            job.

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -337,16 +337,8 @@ class JobQueue(object):
         self.log.debug("_getNextPendingJob|Acquiring lock to job queue.")
         self.queueLock.acquire()
         self.log.debug("_getNextPendingJob|Acquired lock to job queue.")
-
-        # if (self.unassignedJobs.empty()):
-        #     self.queueLock.release()
-        #     return None, None
-
+        # Blocks till the next item is added 
         job = self.unassignedJobs.get()
-        # job = self.liveJobs.get(id)
-        if job is None:
-           raise Exception("Unassigned job not found in live job queue")           
-
         self.log.debug("getNextPendingJob| Releasing lock to job queue.")
         self.queueLock.release()
         self.log.debug("getNextPendingJob| Released lock to job queue.")

--- a/jobQueue.py
+++ b/jobQueue.py
@@ -149,27 +149,6 @@ class JobQueue(object):
 
         return job.id
 
-    # TODO: remove remove since it's not used 
-    def remove(self, id):
-        """remove - Remove job from live queue
-        """
-        status = -1
-        self.log.debug("remove|Acquiring lock to job queue.")
-        self.queueLock.acquire()
-        self.log.debug("remove|Acquired lock to job queue.")
-        if str(id) in self.liveJobs.keys():
-            self.liveJobs.delete(id)
-            status = 0
-
-        self.queueLock.release()
-        self.log.debug("remove|Relased lock to job queue.")
-
-        if status == 0:
-            self.log.debug("Removed job %s from queue" % id)
-        else:
-            self.log.error("Job %s not found in queue" % id)
-        return status
-
     def delJob(self, id, deadjob):
         """ delJob - Implements delJob() interface call
         @param id - The id of the job to remove

--- a/tango.py
+++ b/tango.py
@@ -94,7 +94,12 @@ class TangoServer(object):
         ret = self.__validateJob(job, self.preallocator.vmms)
         self.log.info("Done validating job %s" % (job.name))
         if ret == 0:
-            return self.jobQueue.add(job)
+            while (True):
+                # When there are not enough job ids, -1
+                res = self.jobQueue.add(job)
+                if res >= 0:
+                    break
+            return res
         else:
             self.jobQueue.addDead(job)
             return -1

--- a/tango.py
+++ b/tango.py
@@ -94,12 +94,7 @@ class TangoServer(object):
         ret = self.__validateJob(job, self.preallocator.vmms)
         self.log.info("Done validating job %s" % (job.name))
         if ret == 0:
-            while (True):
-                # When there are not enough job ids, -1
-                res = self.jobQueue.add(job)
-                if res >= 0:
-                    break
-            return res
+           return self.jobQueue.add(job)
         else:
             self.jobQueue.addDead(job)
             return -1

--- a/tangoObjects.py
+++ b/tangoObjects.py
@@ -238,8 +238,9 @@ class TangoRemoteQueue(object):
         else:
             item = self.__db.lpop(self.key)
 
-        # if item:
-        #     item = item[1]
+        if block and item:
+            print(item[0])
+            item = item[1]
 
         item = pickle.loads(item)
         return item

--- a/tangoObjects.py
+++ b/tangoObjects.py
@@ -249,7 +249,6 @@ class TangoRemoteQueue(object):
             return None
 
         if block and item:
-            print(item[0])
             item = item[1]
 
         item = pickle.loads(item)

--- a/tangoObjects.py
+++ b/tangoObjects.py
@@ -238,6 +238,9 @@ class TangoRemoteQueue(object):
         else:
             item = self.__db.lpop(self.key)
 
+        if item is None:
+            return None
+
         if block and item:
             print(item[0])
             item = item[1]

--- a/tests/testJobQueue.py
+++ b/tests/testJobQueue.py
@@ -69,15 +69,6 @@ class TestJobQueue(unittest.TestCase):
     def test_addDead(self):
         return self.assertEqual(1, 1)
 
-    def test_remove(self):
-        self.jobQueue.remove(self.jobId1)
-        info = self.jobQueue.getInfo()
-        self.assertEqual(info['size'], 1)
-
-        self.jobQueue.remove(self.jobId2)
-        info = self.jobQueue.getInfo()
-        self.assertEqual(info['size'], 0)
-
     def test_delJob(self):
         self.jobQueue.delJob(self.jobId1, 0)
         info = self.jobQueue.getInfo()
@@ -100,11 +91,8 @@ class TestJobQueue(unittest.TestCase):
     def test_getNextPendingJob(self):
         self.jobQueue.assignJob(self.jobId2)
         self.jobQueue.unassignJob(self.jobId1)
-        exp_id = self.jobQueue.getNextPendingJob()
-        self.assertMultiLineEqual(exp_id, self.jobId1)
-
-    def test_getNextPendingJobReuse(self):
-        return False
+        exp = self.jobQueue.getNextPendingJob()
+        self.assertMultiLineEqual(str(exp.id), self.jobId1)
 
     def test_assignJob(self):
         self.jobQueue.assignJob(self.jobId1)

--- a/worker.py
+++ b/worker.py
@@ -207,7 +207,9 @@ class Worker(threading.Thread):
                         self.job.vm.name)))
 
                 # Host name returned from EC2 is stored in the vm object
-                self.vmms.initializeVM(self.job.vm)
+                # Note: This call to VM adds the vm to the pool so that it 
+                # will be accounted for
+                self.preallocator.createVM(self.job.vm)
                 self.log.debug("Asigned job to a new VM")
 
             vm = self.job.vm


### PR DESCRIPTION
Fixes #182 and indirectly fixes #142

Changes proposed in this PR:
-  The most glaring issue fixed was [here](https://github.com/autolab/Tango/blob/43feeafb315ab7ac47a24818af95efacc6e8f0a5/jobManager.py#L103). I included a check for whether the pre-allocated VM in jobManager.py returns a `None` before attempting to do the logging. In the case where there are not enough VMs in the pool available, `None` can be returned. This previously caused an exception to be thrown and for the job to be considered Dead instead.
- Added a TangoQueue for unassigned jobs. This keeps a FIFO queue of live jobs that have been added and not yet assigned to a worker or vm. Whenever we `getNextPendingJob`, we simply just have to pop off the FIFO queue. Some implications:
       - This helps to indirectly avoid the possible starvation problem as mentioned in the issue #142, since jobs are assigned or run based on their order in the FIFO queue, rather than arbitrarily based on their jobIDs. 
       - I've also used a blocking call to the redis list `lpop`. This means that `getNextPendingJob` will block until there is a next job available in the job queue. Previously, it seems like we have the jobManager spinning when there are no jobs, which might be less desirable. 
      - To accommodate previous API methods in the jobManager like `delJob` etc., I have added methods to the `TangoQueue` object to add functions to remove items in the queue.  
- Removed some methods in the jobQueue which are not used currently and do not seem to be useful. I also changed the `getNextPendingJobReuse` method so that it will be less expensive. Previously, it was looping through the hash table to find a job and initialiaze a pool of VMs for it. However, this can be simplified if we simply retrieve the job and pass it to a helper function to do this initialization.
- Changed `initializeVM` to `createVM` in the `Worker`-- refer to the note below for more details. 
- Added more comments and docs to the functions within jobQueue. There were several assumptions (or preconditions required) in some methods and made them explicit in these comments. 
-  Added some minor error handling within jobQueue. I checked most of the functions to make sure that error codes are being handled. 
- Fixed some of the unit tests for jobQueue so that it aligns with the modified api.

#### QA
- More tests for this are in the making. We realize there aren't really any integrated tests present currently that makes sure that the `server` and the `jobManager` behaves as expected together, so we may be writing more of these. 

*Note:
- I have previously raised this up in the issue comments, but because of the exception thrown during the logging in jobManager, several branches and code in the `Worker` are not tested and used at all. This is the case when a worker is started with `preVM` is `None`. It seems like the current behavior of the worker will be to `initialize` a new VM whenever there is not already a pre-allocated VM for it. This might cause some issues and unexpected behavior for the case when `Config.REUSE_VMMS` is set to true -- when there is a flood of jobs to the autograder, many of these vms might be created in this worker. Because of the fact that they use the call `initializeVM` to immediately initialize and create a new vm instance, this vm is not added to the pool and is also untracked anywhere else. Based on my limited understanding, it seems like this vm will not be terminated. In the case where ec2ssh is used for example, this might be undesirable. I have replaced this call with `createVM` at least, so that the pool keeps track of this new vm. The preallocator will then manage the pools by terminating instances when there are too many later on. 

However, a more important question is, what is the desired behavior of the autograder when there are not enough VMs? Perhaps we could consider simply blocking the job there, and waiting for another vm to be freed instead of always creating new VMs. This will potentially cause a lot more VMs to be created during peak usage.